### PR TITLE
Added 'unzip' package

### DIFF
--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -1,7 +1,7 @@
 FROM eboraas/apache
 MAINTAINER Ed Boraas <ed@boraas.ca>
 
-RUN apt-get update && apt-get -y install php php-mysql libapache2-mod-php && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y install php php-mysql libapache2-mod-php unzip && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN /usr/sbin/a2enmod mpm_prefork
 
 EXPOSE 80


### PR DESCRIPTION
This is used when installing packages via composer. Without it, PHP unzip is used and Laravel failed to build correctly.